### PR TITLE
fix/eugen/fix-warnings-during-compilation

### DIFF
--- a/web-common/src/main/java/com/brizy/io/web/common/dto/element/properties/counter/CounterProperties.java
+++ b/web-common/src/main/java/com/brizy/io/web/common/dto/element/properties/counter/CounterProperties.java
@@ -2,12 +2,10 @@ package com.brizy.io.web.common.dto.element.properties.counter;
 
 import com.brizy.io.web.common.dto.element.properties.AbstractProperty;
 import com.brizy.io.web.common.dto.element.properties.Property;
-import lombok.AccessLevel;
-import lombok.AllArgsConstructor;
-import lombok.Data;
-import lombok.NoArgsConstructor;
+import lombok.*;
 import lombok.experimental.FieldDefaults;
 
+@EqualsAndHashCode(callSuper = false)
 @AllArgsConstructor
 @NoArgsConstructor(force = true)
 @Data

--- a/web-common/src/main/java/com/brizy/io/web/common/dto/element/properties/image/ImageProperties.java
+++ b/web-common/src/main/java/com/brizy/io/web/common/dto/element/properties/image/ImageProperties.java
@@ -3,12 +3,10 @@ package com.brizy.io.web.common.dto.element.properties.image;
 import com.brizy.io.web.common.dto.element.properties.AbstractProperty;
 import com.brizy.io.web.common.dto.element.properties.Property;
 import com.brizy.io.web.common.dto.element.properties.toolbar.image.Image;
-import lombok.AccessLevel;
-import lombok.AllArgsConstructor;
-import lombok.Data;
-import lombok.NoArgsConstructor;
+import lombok.*;
 import lombok.experimental.FieldDefaults;
 
+@EqualsAndHashCode(callSuper = false)
 @AllArgsConstructor
 @NoArgsConstructor(force = true)
 @FieldDefaults(makeFinal = true, level = AccessLevel.PRIVATE)

--- a/web-interactions/src/main/java/com/brizy/io/web/interactions/page/editor/container/EditorContainer.java
+++ b/web-interactions/src/main/java/com/brizy/io/web/interactions/page/editor/container/EditorContainer.java
@@ -22,6 +22,7 @@ import static java.time.Duration.ZERO;
 import static lombok.AccessLevel.PRIVATE;
 import static org.awaitility.Awaitility.await;
 
+@SuppressWarnings({"unchecked", "ConstantConditions"})
 @FieldDefaults(makeFinal = true, level = PRIVATE)
 public class EditorContainer {
 

--- a/web-kiwi-tcms/src/main/java/com/brizy/io/web/kiwi/tcms/dto/request/BuildByPlanVersionRequestDto.java
+++ b/web-kiwi-tcms/src/main/java/com/brizy/io/web/kiwi/tcms/dto/request/BuildByPlanVersionRequestDto.java
@@ -4,10 +4,12 @@ import com.brizy.io.web.kiwi.tcms.dto.JsonRpcDto;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import lombok.Builder;
 import lombok.Data;
+import lombok.EqualsAndHashCode;
 import lombok.experimental.SuperBuilder;
 
 import java.util.List;
 
+@EqualsAndHashCode(callSuper = false)
 @Data
 @SuperBuilder(toBuilder = true)
 public class BuildByPlanVersionRequestDto extends JsonRpcDto {

--- a/web-kiwi-tcms/src/main/java/com/brizy/io/web/kiwi/tcms/dto/request/LoginRequestDto.java
+++ b/web-kiwi-tcms/src/main/java/com/brizy/io/web/kiwi/tcms/dto/request/LoginRequestDto.java
@@ -4,10 +4,12 @@ import com.brizy.io.web.kiwi.tcms.dto.JsonRpcDto;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import lombok.Builder;
 import lombok.Data;
+import lombok.EqualsAndHashCode;
 import lombok.experimental.SuperBuilder;
 
 import java.util.List;
 
+@EqualsAndHashCode(callSuper = false)
 @Data
 @SuperBuilder(toBuilder = true)
 public class LoginRequestDto extends JsonRpcDto {

--- a/web-kiwi-tcms/src/main/java/com/brizy/io/web/kiwi/tcms/dto/request/TestPlanRequestDto.java
+++ b/web-kiwi-tcms/src/main/java/com/brizy/io/web/kiwi/tcms/dto/request/TestPlanRequestDto.java
@@ -4,8 +4,10 @@ import com.brizy.io.web.kiwi.tcms.dto.JsonRpcDto;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import lombok.Builder;
 import lombok.Data;
+import lombok.EqualsAndHashCode;
 import lombok.experimental.SuperBuilder;
 
+@EqualsAndHashCode(callSuper = false)
 @Data
 @SuperBuilder(toBuilder = true)
 public class TestPlanRequestDto extends JsonRpcDto {

--- a/web-kiwi-tcms/src/main/java/com/brizy/io/web/kiwi/tcms/dto/request/build/BuildByNameRequestDto.java
+++ b/web-kiwi-tcms/src/main/java/com/brizy/io/web/kiwi/tcms/dto/request/build/BuildByNameRequestDto.java
@@ -4,10 +4,12 @@ import com.brizy.io.web.kiwi.tcms.dto.JsonRpcDto;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import lombok.Builder;
 import lombok.Data;
+import lombok.EqualsAndHashCode;
 import lombok.experimental.SuperBuilder;
 
 import java.util.List;
 
+@EqualsAndHashCode(callSuper = false)
 @Data
 @SuperBuilder(toBuilder = true)
 public class BuildByNameRequestDto extends JsonRpcDto {

--- a/web-kiwi-tcms/src/main/java/com/brizy/io/web/kiwi/tcms/dto/request/build/CreateBuildRequestDto.java
+++ b/web-kiwi-tcms/src/main/java/com/brizy/io/web/kiwi/tcms/dto/request/build/CreateBuildRequestDto.java
@@ -4,10 +4,12 @@ import com.brizy.io.web.kiwi.tcms.dto.JsonRpcDto;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import lombok.Builder;
 import lombok.Data;
+import lombok.EqualsAndHashCode;
 import lombok.experimental.SuperBuilder;
 
 import java.util.List;
 
+@EqualsAndHashCode(callSuper = false)
 @Data
 @SuperBuilder(toBuilder = true)
 public class CreateBuildRequestDto extends JsonRpcDto {

--- a/web-kiwi-tcms/src/main/java/com/brizy/io/web/kiwi/tcms/dto/request/classification/ClassificationByNameRequestDto.java
+++ b/web-kiwi-tcms/src/main/java/com/brizy/io/web/kiwi/tcms/dto/request/classification/ClassificationByNameRequestDto.java
@@ -4,10 +4,12 @@ import com.brizy.io.web.kiwi.tcms.dto.JsonRpcDto;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import lombok.Builder;
 import lombok.Data;
+import lombok.EqualsAndHashCode;
 import lombok.experimental.SuperBuilder;
 
 import java.util.List;
 
+@EqualsAndHashCode(callSuper = false)
 @Data
 @SuperBuilder(toBuilder = true)
 public class ClassificationByNameRequestDto extends JsonRpcDto {

--- a/web-kiwi-tcms/src/main/java/com/brizy/io/web/kiwi/tcms/dto/request/classification/CreateClassificationRequestDto.java
+++ b/web-kiwi-tcms/src/main/java/com/brizy/io/web/kiwi/tcms/dto/request/classification/CreateClassificationRequestDto.java
@@ -4,10 +4,12 @@ import com.brizy.io.web.kiwi.tcms.dto.JsonRpcDto;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import lombok.Builder;
 import lombok.Data;
+import lombok.EqualsAndHashCode;
 import lombok.experimental.SuperBuilder;
 
 import java.util.List;
 
+@EqualsAndHashCode(callSuper = false)
 @Data
 @SuperBuilder(toBuilder = true)
 public class CreateClassificationRequestDto extends JsonRpcDto {

--- a/web-kiwi-tcms/src/main/java/com/brizy/io/web/kiwi/tcms/dto/request/product/CreateProductRequestDto.java
+++ b/web-kiwi-tcms/src/main/java/com/brizy/io/web/kiwi/tcms/dto/request/product/CreateProductRequestDto.java
@@ -4,10 +4,12 @@ import com.brizy.io.web.kiwi.tcms.dto.JsonRpcDto;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import lombok.Builder;
 import lombok.Data;
+import lombok.EqualsAndHashCode;
 import lombok.experimental.SuperBuilder;
 
 import java.util.List;
 
+@EqualsAndHashCode(callSuper = false)
 @Data
 @SuperBuilder(toBuilder = true)
 public class CreateProductRequestDto extends JsonRpcDto {

--- a/web-kiwi-tcms/src/main/java/com/brizy/io/web/kiwi/tcms/dto/request/product/ProductByNameRequestDto.java
+++ b/web-kiwi-tcms/src/main/java/com/brizy/io/web/kiwi/tcms/dto/request/product/ProductByNameRequestDto.java
@@ -4,10 +4,12 @@ import com.brizy.io.web.kiwi.tcms.dto.JsonRpcDto;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import lombok.Builder;
 import lombok.Data;
+import lombok.EqualsAndHashCode;
 import lombok.experimental.SuperBuilder;
 
 import java.util.List;
 
+@EqualsAndHashCode(callSuper = false)
 @Data
 @SuperBuilder(toBuilder = true)
 public class ProductByNameRequestDto extends JsonRpcDto {

--- a/web-kiwi-tcms/src/main/java/com/brizy/io/web/kiwi/tcms/dto/request/test_case/CreateTestCaseRequestDto.java
+++ b/web-kiwi-tcms/src/main/java/com/brizy/io/web/kiwi/tcms/dto/request/test_case/CreateTestCaseRequestDto.java
@@ -4,10 +4,12 @@ import com.brizy.io.web.kiwi.tcms.dto.JsonRpcDto;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import lombok.Builder;
 import lombok.Data;
+import lombok.EqualsAndHashCode;
 import lombok.experimental.SuperBuilder;
 
 import java.util.List;
 
+@EqualsAndHashCode(callSuper = false)
 @Data
 @SuperBuilder(toBuilder = true)
 public class CreateTestCaseRequestDto extends JsonRpcDto {

--- a/web-kiwi-tcms/src/main/java/com/brizy/io/web/kiwi/tcms/dto/request/test_case/TestCaseByNameRequestDto.java
+++ b/web-kiwi-tcms/src/main/java/com/brizy/io/web/kiwi/tcms/dto/request/test_case/TestCaseByNameRequestDto.java
@@ -4,10 +4,12 @@ import com.brizy.io.web.kiwi.tcms.dto.JsonRpcDto;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import lombok.Builder;
 import lombok.Data;
+import lombok.EqualsAndHashCode;
 import lombok.experimental.SuperBuilder;
 
 import java.util.List;
 
+@EqualsAndHashCode(callSuper = false)
 @Data
 @SuperBuilder(toBuilder = true)
 public class TestCaseByNameRequestDto extends JsonRpcDto {

--- a/web-kiwi-tcms/src/main/java/com/brizy/io/web/kiwi/tcms/dto/request/test_case/UpdateTestCaseDurationRequestDto.java
+++ b/web-kiwi-tcms/src/main/java/com/brizy/io/web/kiwi/tcms/dto/request/test_case/UpdateTestCaseDurationRequestDto.java
@@ -4,10 +4,12 @@ import com.brizy.io.web.kiwi.tcms.dto.JsonRpcDto;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import lombok.Builder;
 import lombok.Data;
+import lombok.EqualsAndHashCode;
 import lombok.experimental.SuperBuilder;
 
 import java.util.List;
 
+@EqualsAndHashCode(callSuper = false)
 @Data
 @SuperBuilder(toBuilder = true)
 public class UpdateTestCaseDurationRequestDto extends JsonRpcDto {

--- a/web-kiwi-tcms/src/main/java/com/brizy/io/web/kiwi/tcms/dto/request/test_execution/UpdateTestExecutionStatusRequestDto.java
+++ b/web-kiwi-tcms/src/main/java/com/brizy/io/web/kiwi/tcms/dto/request/test_execution/UpdateTestExecutionStatusRequestDto.java
@@ -4,10 +4,12 @@ import com.brizy.io.web.kiwi.tcms.dto.JsonRpcDto;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import lombok.Builder;
 import lombok.Data;
+import lombok.EqualsAndHashCode;
 import lombok.experimental.SuperBuilder;
 
 import java.util.List;
 
+@EqualsAndHashCode(callSuper = false)
 @Data
 @SuperBuilder(toBuilder = true)
 public class UpdateTestExecutionStatusRequestDto extends JsonRpcDto {

--- a/web-kiwi-tcms/src/main/java/com/brizy/io/web/kiwi/tcms/dto/request/test_plan/AddTestCaseToTestPlanRequestDto.java
+++ b/web-kiwi-tcms/src/main/java/com/brizy/io/web/kiwi/tcms/dto/request/test_plan/AddTestCaseToTestPlanRequestDto.java
@@ -4,10 +4,12 @@ import com.brizy.io.web.kiwi.tcms.dto.JsonRpcDto;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import lombok.Builder;
 import lombok.Data;
+import lombok.EqualsAndHashCode;
 import lombok.experimental.SuperBuilder;
 
 import java.util.List;
 
+@EqualsAndHashCode(callSuper = false)
 @Data
 @SuperBuilder(toBuilder = true)
 public class AddTestCaseToTestPlanRequestDto extends JsonRpcDto {

--- a/web-kiwi-tcms/src/main/java/com/brizy/io/web/kiwi/tcms/dto/request/test_plan/CreateTestPlanRequestDto.java
+++ b/web-kiwi-tcms/src/main/java/com/brizy/io/web/kiwi/tcms/dto/request/test_plan/CreateTestPlanRequestDto.java
@@ -4,10 +4,12 @@ import com.brizy.io.web.kiwi.tcms.dto.JsonRpcDto;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import lombok.Builder;
 import lombok.Data;
+import lombok.EqualsAndHashCode;
 import lombok.experimental.SuperBuilder;
 
 import java.util.List;
 
+@EqualsAndHashCode(callSuper = false)
 @Data
 @SuperBuilder(toBuilder = true)
 public class CreateTestPlanRequestDto extends JsonRpcDto {

--- a/web-kiwi-tcms/src/main/java/com/brizy/io/web/kiwi/tcms/dto/request/test_plan/TestPlanByNameRequestDto.java
+++ b/web-kiwi-tcms/src/main/java/com/brizy/io/web/kiwi/tcms/dto/request/test_plan/TestPlanByNameRequestDto.java
@@ -4,10 +4,12 @@ import com.brizy.io.web.kiwi.tcms.dto.JsonRpcDto;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import lombok.Builder;
 import lombok.Data;
+import lombok.EqualsAndHashCode;
 import lombok.experimental.SuperBuilder;
 
 import java.util.List;
 
+@EqualsAndHashCode(callSuper = false)
 @Data
 @SuperBuilder(toBuilder = true)
 public class TestPlanByNameRequestDto extends JsonRpcDto {

--- a/web-kiwi-tcms/src/main/java/com/brizy/io/web/kiwi/tcms/dto/request/test_run/AddTestCaseToTestRunRequestDto.java
+++ b/web-kiwi-tcms/src/main/java/com/brizy/io/web/kiwi/tcms/dto/request/test_run/AddTestCaseToTestRunRequestDto.java
@@ -4,10 +4,12 @@ import com.brizy.io.web.kiwi.tcms.dto.JsonRpcDto;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import lombok.Builder;
 import lombok.Data;
+import lombok.EqualsAndHashCode;
 import lombok.experimental.SuperBuilder;
 
 import java.util.List;
 
+@EqualsAndHashCode(callSuper = false)
 @Data
 @SuperBuilder(toBuilder = true)
 public class AddTestCaseToTestRunRequestDto extends JsonRpcDto {

--- a/web-kiwi-tcms/src/main/java/com/brizy/io/web/kiwi/tcms/dto/request/test_run/CreateTestRunRequestDto.java
+++ b/web-kiwi-tcms/src/main/java/com/brizy/io/web/kiwi/tcms/dto/request/test_run/CreateTestRunRequestDto.java
@@ -4,10 +4,12 @@ import com.brizy.io.web.kiwi.tcms.dto.JsonRpcDto;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import lombok.Builder;
 import lombok.Data;
+import lombok.EqualsAndHashCode;
 import lombok.experimental.SuperBuilder;
 
 import java.util.List;
 
+@EqualsAndHashCode(callSuper = false)
 @Data
 @SuperBuilder(toBuilder = true)
 public class CreateTestRunRequestDto extends JsonRpcDto {

--- a/web-kiwi-tcms/src/main/java/com/brizy/io/web/kiwi/tcms/dto/request/test_run/TestRunByNameRequestDto.java
+++ b/web-kiwi-tcms/src/main/java/com/brizy/io/web/kiwi/tcms/dto/request/test_run/TestRunByNameRequestDto.java
@@ -4,10 +4,12 @@ import com.brizy.io.web.kiwi.tcms.dto.JsonRpcDto;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import lombok.Builder;
 import lombok.Data;
+import lombok.EqualsAndHashCode;
 import lombok.experimental.SuperBuilder;
 
 import java.util.List;
 
+@EqualsAndHashCode(callSuper = false)
 @Data
 @SuperBuilder(toBuilder = true)
 public class TestRunByNameRequestDto extends JsonRpcDto {

--- a/web-kiwi-tcms/src/main/java/com/brizy/io/web/kiwi/tcms/dto/request/test_run/UpdateTestRunTimestampsRequestDto.java
+++ b/web-kiwi-tcms/src/main/java/com/brizy/io/web/kiwi/tcms/dto/request/test_run/UpdateTestRunTimestampsRequestDto.java
@@ -4,10 +4,12 @@ import com.brizy.io.web.kiwi.tcms.dto.JsonRpcDto;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import lombok.Builder;
 import lombok.Data;
+import lombok.EqualsAndHashCode;
 import lombok.experimental.SuperBuilder;
 
 import java.util.List;
 
+@EqualsAndHashCode(callSuper = false)
 @Data
 @SuperBuilder(toBuilder = true)
 public class UpdateTestRunTimestampsRequestDto extends JsonRpcDto {

--- a/web-kiwi-tcms/src/main/java/com/brizy/io/web/kiwi/tcms/dto/request/version/CreateVersionRequestDto.java
+++ b/web-kiwi-tcms/src/main/java/com/brizy/io/web/kiwi/tcms/dto/request/version/CreateVersionRequestDto.java
@@ -4,10 +4,12 @@ import com.brizy.io.web.kiwi.tcms.dto.JsonRpcDto;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import lombok.Builder;
 import lombok.Data;
+import lombok.EqualsAndHashCode;
 import lombok.experimental.SuperBuilder;
 
 import java.util.List;
 
+@EqualsAndHashCode(callSuper = false)
 @Data
 @SuperBuilder(toBuilder = true)
 public class CreateVersionRequestDto extends JsonRpcDto {

--- a/web-kiwi-tcms/src/main/java/com/brizy/io/web/kiwi/tcms/dto/request/version/VersionByNameRequestDto.java
+++ b/web-kiwi-tcms/src/main/java/com/brizy/io/web/kiwi/tcms/dto/request/version/VersionByNameRequestDto.java
@@ -4,10 +4,12 @@ import com.brizy.io.web.kiwi.tcms.dto.JsonRpcDto;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import lombok.Builder;
 import lombok.Data;
+import lombok.EqualsAndHashCode;
 import lombok.experimental.SuperBuilder;
 
 import java.util.List;
 
+@EqualsAndHashCode(callSuper = false)
 @Data
 @SuperBuilder(toBuilder = true)
 public class VersionByNameRequestDto extends JsonRpcDto {

--- a/web-kiwi-tcms/src/main/java/com/brizy/io/web/kiwi/tcms/dto/response/CreateResponseDto.java
+++ b/web-kiwi-tcms/src/main/java/com/brizy/io/web/kiwi/tcms/dto/response/CreateResponseDto.java
@@ -1,9 +1,11 @@
 package com.brizy.io.web.kiwi.tcms.dto.response;
 
 import lombok.Data;
+import lombok.EqualsAndHashCode;
 
 import java.util.List;
 
+@EqualsAndHashCode(callSuper = false)
 @Data
 public class CreateResponseDto<T> extends AbstractResponseDto {
 

--- a/web-kiwi-tcms/src/main/java/com/brizy/io/web/kiwi/tcms/dto/response/GetResponseDto.java
+++ b/web-kiwi-tcms/src/main/java/com/brizy/io/web/kiwi/tcms/dto/response/GetResponseDto.java
@@ -1,9 +1,11 @@
 package com.brizy.io.web.kiwi.tcms.dto.response;
 
 import lombok.Data;
+import lombok.EqualsAndHashCode;
 
 import java.util.List;
 
+@EqualsAndHashCode(callSuper = false)
 @Data
 public class GetResponseDto<T> extends AbstractResponseDto {
 

--- a/web-kiwi-tcms/src/main/java/com/brizy/io/web/kiwi/tcms/dto/response/build/BuildResponseDto.java
+++ b/web-kiwi-tcms/src/main/java/com/brizy/io/web/kiwi/tcms/dto/response/build/BuildResponseDto.java
@@ -3,7 +3,9 @@ package com.brizy.io.web.kiwi.tcms.dto.response.build;
 import com.brizy.io.web.kiwi.tcms.dto.response.GetResponseDto;
 import lombok.Builder;
 import lombok.Data;
+import lombok.EqualsAndHashCode;
 
+@EqualsAndHashCode(callSuper = false)
 @Data
 @Builder(toBuilder = true)
 public class BuildResponseDto extends GetResponseDto<BuildDto> {

--- a/web-kiwi-tcms/src/main/java/com/brizy/io/web/kiwi/tcms/dto/response/build/CreateBuildResponseDto.java
+++ b/web-kiwi-tcms/src/main/java/com/brizy/io/web/kiwi/tcms/dto/response/build/CreateBuildResponseDto.java
@@ -3,7 +3,9 @@ package com.brizy.io.web.kiwi.tcms.dto.response.build;
 import com.brizy.io.web.kiwi.tcms.dto.response.CreateResponseDto;
 import lombok.Builder;
 import lombok.Data;
+import lombok.EqualsAndHashCode;
 
+@EqualsAndHashCode(callSuper = false)
 @Data
 @Builder(toBuilder = true)
 public class CreateBuildResponseDto extends CreateResponseDto<BuildDto> {

--- a/web-kiwi-tcms/src/main/java/com/brizy/io/web/kiwi/tcms/dto/response/classification/ClassificationResponseDto.java
+++ b/web-kiwi-tcms/src/main/java/com/brizy/io/web/kiwi/tcms/dto/response/classification/ClassificationResponseDto.java
@@ -3,7 +3,9 @@ package com.brizy.io.web.kiwi.tcms.dto.response.classification;
 import com.brizy.io.web.kiwi.tcms.dto.response.GetResponseDto;
 import lombok.Builder;
 import lombok.Data;
+import lombok.EqualsAndHashCode;
 
+@EqualsAndHashCode(callSuper = false)
 @Data
 @Builder(toBuilder = true)
 public class ClassificationResponseDto extends GetResponseDto<ClassificationDto> {

--- a/web-kiwi-tcms/src/main/java/com/brizy/io/web/kiwi/tcms/dto/response/classification/CreateClassificationResponseDto.java
+++ b/web-kiwi-tcms/src/main/java/com/brizy/io/web/kiwi/tcms/dto/response/classification/CreateClassificationResponseDto.java
@@ -3,7 +3,9 @@ package com.brizy.io.web.kiwi.tcms.dto.response.classification;
 import com.brizy.io.web.kiwi.tcms.dto.response.CreateResponseDto;
 import lombok.Builder;
 import lombok.Data;
+import lombok.EqualsAndHashCode;
 
+@EqualsAndHashCode(callSuper = false)
 @Data
 @Builder(toBuilder = true)
 public class CreateClassificationResponseDto extends CreateResponseDto<ClassificationDto> {

--- a/web-kiwi-tcms/src/main/java/com/brizy/io/web/kiwi/tcms/dto/response/product/CreateProductResponseDto.java
+++ b/web-kiwi-tcms/src/main/java/com/brizy/io/web/kiwi/tcms/dto/response/product/CreateProductResponseDto.java
@@ -4,7 +4,9 @@ import com.brizy.io.web.kiwi.tcms.dto.response.CreateResponseDto;
 import com.brizy.io.web.kiwi.tcms.dto.response.classification.ClassificationDto;
 import lombok.Builder;
 import lombok.Data;
+import lombok.EqualsAndHashCode;
 
+@EqualsAndHashCode(callSuper = false)
 @Data
 @Builder(toBuilder = true)
 public class CreateProductResponseDto extends CreateResponseDto<ProductDto> {

--- a/web-kiwi-tcms/src/main/java/com/brizy/io/web/kiwi/tcms/dto/response/product/ProductResponseDto.java
+++ b/web-kiwi-tcms/src/main/java/com/brizy/io/web/kiwi/tcms/dto/response/product/ProductResponseDto.java
@@ -4,7 +4,9 @@ import com.brizy.io.web.kiwi.tcms.dto.response.GetResponseDto;
 import com.brizy.io.web.kiwi.tcms.dto.response.product.ProductDto;
 import lombok.Builder;
 import lombok.Data;
+import lombok.EqualsAndHashCode;
 
+@EqualsAndHashCode(callSuper = false)
 @Data
 @Builder(toBuilder = true)
 public class ProductResponseDto extends GetResponseDto<ProductDto> {

--- a/web-kiwi-tcms/src/main/java/com/brizy/io/web/kiwi/tcms/dto/response/test_case/CreateTestCaseResponseDto.java
+++ b/web-kiwi-tcms/src/main/java/com/brizy/io/web/kiwi/tcms/dto/response/test_case/CreateTestCaseResponseDto.java
@@ -3,7 +3,9 @@ package com.brizy.io.web.kiwi.tcms.dto.response.test_case;
 import com.brizy.io.web.kiwi.tcms.dto.response.CreateResponseDto;
 import lombok.Builder;
 import lombok.Data;
+import lombok.EqualsAndHashCode;
 
+@EqualsAndHashCode(callSuper = false)
 @Data
 @Builder(toBuilder = true)
 public class CreateTestCaseResponseDto extends CreateResponseDto<CreateTestCaseDto> {

--- a/web-kiwi-tcms/src/main/java/com/brizy/io/web/kiwi/tcms/dto/response/test_case/TestCaseResponseDto.java
+++ b/web-kiwi-tcms/src/main/java/com/brizy/io/web/kiwi/tcms/dto/response/test_case/TestCaseResponseDto.java
@@ -3,7 +3,9 @@ package com.brizy.io.web.kiwi.tcms.dto.response.test_case;
 import com.brizy.io.web.kiwi.tcms.dto.response.GetResponseDto;
 import lombok.Builder;
 import lombok.Data;
+import lombok.EqualsAndHashCode;
 
+@EqualsAndHashCode(callSuper = false)
 @Data
 @Builder(toBuilder = true)
 public class TestCaseResponseDto extends GetResponseDto<GetTestCaseDto> {

--- a/web-kiwi-tcms/src/main/java/com/brizy/io/web/kiwi/tcms/dto/response/test_plan/AddTestCaseToTestPlanResponseDto.java
+++ b/web-kiwi-tcms/src/main/java/com/brizy/io/web/kiwi/tcms/dto/response/test_plan/AddTestCaseToTestPlanResponseDto.java
@@ -4,9 +4,11 @@ import com.brizy.io.web.kiwi.tcms.dto.response.AbstractResponseDto;
 import com.brizy.io.web.kiwi.tcms.dto.response.CreateResponseDto;
 import com.brizy.io.web.kiwi.tcms.dto.response.test_run.AddTestCaseToTestRunDto;
 import lombok.Data;
+import lombok.EqualsAndHashCode;
 
 import java.util.List;
 
+@EqualsAndHashCode(callSuper = false)
 @Data
 public class AddTestCaseToTestPlanResponseDto extends CreateResponseDto<AddTestCaseToTestPlanDto> {
 }

--- a/web-kiwi-tcms/src/main/java/com/brizy/io/web/kiwi/tcms/dto/response/test_plan/CreateTestPlanResponseDto.java
+++ b/web-kiwi-tcms/src/main/java/com/brizy/io/web/kiwi/tcms/dto/response/test_plan/CreateTestPlanResponseDto.java
@@ -3,7 +3,9 @@ package com.brizy.io.web.kiwi.tcms.dto.response.test_plan;
 import com.brizy.io.web.kiwi.tcms.dto.response.CreateResponseDto;
 import lombok.Builder;
 import lombok.Data;
+import lombok.EqualsAndHashCode;
 
+@EqualsAndHashCode(callSuper = false)
 @Data
 @Builder(toBuilder = true)
 public class CreateTestPlanResponseDto extends CreateResponseDto<CreateTestPlanDto> {

--- a/web-kiwi-tcms/src/main/java/com/brizy/io/web/kiwi/tcms/dto/response/test_plan/TestPlanResponseDto.java
+++ b/web-kiwi-tcms/src/main/java/com/brizy/io/web/kiwi/tcms/dto/response/test_plan/TestPlanResponseDto.java
@@ -3,7 +3,9 @@ package com.brizy.io.web.kiwi.tcms.dto.response.test_plan;
 import com.brizy.io.web.kiwi.tcms.dto.response.GetResponseDto;
 import lombok.Builder;
 import lombok.Data;
+import lombok.EqualsAndHashCode;
 
+@EqualsAndHashCode(callSuper = false)
 @Data
 @Builder(toBuilder = true)
 public class TestPlanResponseDto extends GetResponseDto<GetTestPlanDto> {

--- a/web-kiwi-tcms/src/main/java/com/brizy/io/web/kiwi/tcms/dto/response/test_run/AddTestCaseToTestRunResponseDto.java
+++ b/web-kiwi-tcms/src/main/java/com/brizy/io/web/kiwi/tcms/dto/response/test_run/AddTestCaseToTestRunResponseDto.java
@@ -3,9 +3,11 @@ package com.brizy.io.web.kiwi.tcms.dto.response.test_run;
 import com.brizy.io.web.kiwi.tcms.dto.response.AbstractResponseDto;
 import com.brizy.io.web.kiwi.tcms.dto.response.CreateResponseDto;
 import lombok.Data;
+import lombok.EqualsAndHashCode;
 
 import java.util.List;
 
+@EqualsAndHashCode(callSuper = false)
 @Data
 public class AddTestCaseToTestRunResponseDto extends AbstractResponseDto {
 

--- a/web-kiwi-tcms/src/main/java/com/brizy/io/web/kiwi/tcms/dto/response/test_run/CreateTestRunResponseDto.java
+++ b/web-kiwi-tcms/src/main/java/com/brizy/io/web/kiwi/tcms/dto/response/test_run/CreateTestRunResponseDto.java
@@ -3,7 +3,9 @@ package com.brizy.io.web.kiwi.tcms.dto.response.test_run;
 import com.brizy.io.web.kiwi.tcms.dto.response.CreateResponseDto;
 import lombok.Builder;
 import lombok.Data;
+import lombok.EqualsAndHashCode;
 
+@EqualsAndHashCode(callSuper = false)
 @Data
 @Builder(toBuilder = true)
 public class CreateTestRunResponseDto extends CreateResponseDto<CreateTestRunDto> {

--- a/web-kiwi-tcms/src/main/java/com/brizy/io/web/kiwi/tcms/dto/response/test_run/TestRunResponseDto.java
+++ b/web-kiwi-tcms/src/main/java/com/brizy/io/web/kiwi/tcms/dto/response/test_run/TestRunResponseDto.java
@@ -3,7 +3,9 @@ package com.brizy.io.web.kiwi.tcms.dto.response.test_run;
 import com.brizy.io.web.kiwi.tcms.dto.response.GetResponseDto;
 import lombok.Builder;
 import lombok.Data;
+import lombok.EqualsAndHashCode;
 
+@EqualsAndHashCode(callSuper = false)
 @Data
 @Builder(toBuilder = true)
 public class TestRunResponseDto extends GetResponseDto<GetTestRunDto> {

--- a/web-kiwi-tcms/src/main/java/com/brizy/io/web/kiwi/tcms/dto/response/version/CreateVersionResponseDto.java
+++ b/web-kiwi-tcms/src/main/java/com/brizy/io/web/kiwi/tcms/dto/response/version/CreateVersionResponseDto.java
@@ -3,7 +3,9 @@ package com.brizy.io.web.kiwi.tcms.dto.response.version;
 import com.brizy.io.web.kiwi.tcms.dto.response.CreateResponseDto;
 import lombok.Builder;
 import lombok.Data;
+import lombok.EqualsAndHashCode;
 
+@EqualsAndHashCode(callSuper = false)
 @Data
 @Builder(toBuilder = true)
 public class CreateVersionResponseDto extends CreateResponseDto<VersionDto> {

--- a/web-kiwi-tcms/src/main/java/com/brizy/io/web/kiwi/tcms/dto/response/version/VersionResponseDto.java
+++ b/web-kiwi-tcms/src/main/java/com/brizy/io/web/kiwi/tcms/dto/response/version/VersionResponseDto.java
@@ -3,7 +3,9 @@ package com.brizy.io.web.kiwi.tcms.dto.response.version;
 import com.brizy.io.web.kiwi.tcms.dto.response.GetResponseDto;
 import lombok.Builder;
 import lombok.Data;
+import lombok.EqualsAndHashCode;
 
+@EqualsAndHashCode(callSuper = false)
 @Data
 @Builder(toBuilder = true)
 public class VersionResponseDto extends GetResponseDto<VersionDto> {

--- a/web-kiwi-tcms/src/main/java/com/brizy/io/web/kiwi/tcms/service/AbstractService.java
+++ b/web-kiwi-tcms/src/main/java/com/brizy/io/web/kiwi/tcms/service/AbstractService.java
@@ -14,6 +14,7 @@ import java.util.Optional;
 
 @FieldDefaults(makeFinal = true, level = AccessLevel.PRIVATE)
 @NoArgsConstructor(force = true)
+@SuppressWarnings({"unchecked", "ConstantConditions"})
 @RequiredArgsConstructor
 public abstract class AbstractService {
 

--- a/web-test/src/test/java/com/brizy/io/web/test/storage/Storage.java
+++ b/web-test/src/test/java/com/brizy/io/web/test/storage/Storage.java
@@ -16,6 +16,7 @@ import static lombok.AccessLevel.PRIVATE;
 @Component
 @FieldDefaults(makeFinal = true, level = PRIVATE)
 @ScenarioScope
+@SuppressWarnings({"unchecked", "rawtypes"})
 public class Storage {
 
     Map<StorageKey, Object> store;


### PR DESCRIPTION
* Added @EqualsAndHashCode(callSuper = false) to avoid warnings during compilation of classes that inherits other functionality and are annotated with @Data that is generating an implementation of equals and hash code that needs to be configured for super class calling.