### PR TITLE
feature/eugen/adding-scenario-to-check-default-items-for-icon-section-in-toolbar

### DIFF
--- a/web-common/src/main/java/com/brizy/io/web/common/dto/element/properties/button/button/icon/size/IconSizes.java
+++ b/web-common/src/main/java/com/brizy/io/web/common/dto/element/properties/button/button/icon/size/IconSizes.java
@@ -10,9 +10,9 @@ import lombok.experimental.FieldDefaults;
 @FieldDefaults(makeFinal = true, level = AccessLevel.PRIVATE)
 public enum IconSizes implements Enumerable<IconSizes> {
 
-    SIZE_16("nc-16"),
-    SIZE_24("nc-24"),
     SIZE_32("nc-32"),
+    SIZE_48("nc-48"),
+    SIZE_64("nc-64"),
     CUSTOM("nc-more");
 
     @Getter

--- a/web-interactions/src/main/java/com/brizy/io/web/interactions/page/editor/container/components/toolbar/variations/button/button/button/corner/Corner.java
+++ b/web-interactions/src/main/java/com/brizy/io/web/interactions/page/editor/container/components/toolbar/variations/button/button/button/corner/Corner.java
@@ -1,15 +1,19 @@
 package com.brizy.io.web.interactions.page.editor.container.components.toolbar.variations.button.button.button.corner;
 
 import com.brizy.io.web.common.dto.element.properties.common.corner.*;
+import com.brizy.io.web.interactions.dto.editor.container.toolbar.Configuration;
 import com.brizy.io.web.interactions.element.NumericInput;
 import com.brizy.io.web.interactions.element.composite.RadioControl;
 import com.brizy.io.web.interactions.locators.editor.workspace.section.container.item.toolbar.button.tabs.button.corner.CornerLocators;
 import com.microsoft.playwright.Frame;
 import lombok.AccessLevel;
 import lombok.experimental.FieldDefaults;
+import lombok.experimental.FieldNameConstants;
 
+import java.util.List;
 import java.util.function.Supplier;
 
+@FieldNameConstants
 @FieldDefaults(makeFinal = true, level = AccessLevel.PRIVATE)
 public class Corner {
 
@@ -43,4 +47,12 @@ public class Corner {
                 .corner(selectedCorner)
                 .build();
     }
+
+    public List<Configuration> getConfigurations() {
+        return List.of(
+                Configuration.builder().name(Fields.corner).element(corner).build(),
+                Configuration.builder().name(Fields.radius).element(radius).build()
+        );
+    }
+
 }

--- a/web-interactions/src/main/java/com/brizy/io/web/interactions/page/editor/container/components/toolbar/variations/button/button/icon/size/IconSize.java
+++ b/web-interactions/src/main/java/com/brizy/io/web/interactions/page/editor/container/components/toolbar/variations/button/button/icon/size/IconSize.java
@@ -4,15 +4,19 @@ import com.brizy.io.web.common.dto.element.properties.button.button.icon.size.Co
 import com.brizy.io.web.common.dto.element.properties.button.button.icon.size.CustomSize;
 import com.brizy.io.web.common.dto.element.properties.button.button.icon.size.IconSizes;
 import com.brizy.io.web.common.dto.element.properties.button.button.icon.size.Size;
+import com.brizy.io.web.interactions.dto.editor.container.toolbar.Configuration;
 import com.brizy.io.web.interactions.element.NumericInput;
 import com.brizy.io.web.interactions.element.composite.RadioControl;
 import com.brizy.io.web.interactions.locators.editor.workspace.section.container.item.toolbar.button.tabs.icon.size.SizeLocators;
 import com.microsoft.playwright.Frame;
 import lombok.AccessLevel;
 import lombok.experimental.FieldDefaults;
+import lombok.experimental.FieldNameConstants;
 
+import java.util.List;
 import java.util.function.Supplier;
 
+@FieldNameConstants
 @FieldDefaults(makeFinal = true, level = AccessLevel.PRIVATE)
 public class IconSize {
 
@@ -20,7 +24,7 @@ public class IconSize {
     Supplier<NumericInput> customSize;
 
     public IconSize(SizeLocators size, Frame frame) {
-        this.size = () -> new RadioControl<>(IconSizes.class, size.getSelf(), frame.page());
+        this.size = () -> new RadioControl<>(IconSizes.class, size.getSelf(), frame);
         this.customSize = () -> new NumericInput(frame.locator(size.getCustom().getValue()));
     }
 
@@ -43,6 +47,13 @@ public class IconSize {
         return ConcreteSize.builder()
                 .size(activeSize)
                 .build();
+    }
+
+    public List<Configuration> getConfigurations() {
+        return List.of(
+                Configuration.builder().name(Fields.size).element(size).build(),
+                Configuration.builder().name(Fields.customSize).element(customSize).build()
+        );
     }
 
 }

--- a/web-interactions/src/main/java/com/brizy/io/web/interactions/page/editor/container/components/toolbar/variations/icon/background/BackgroundTab.java
+++ b/web-interactions/src/main/java/com/brizy/io/web/interactions/page/editor/container/components/toolbar/variations/icon/background/BackgroundTab.java
@@ -1,26 +1,26 @@
 package com.brizy.io.web.interactions.page.editor.container.components.toolbar.variations.icon.background;
 
-import com.brizy.io.web.common.dto.element.properties.button.button.button.ButtonTabProperties;
 import com.brizy.io.web.common.dto.element.properties.common.fill.FillTypes;
 import com.brizy.io.web.common.dto.element.properties.icon.tabs.background.BackgroundTabProperties;
 import com.brizy.io.web.interactions.dto.editor.container.toolbar.Configuration;
 import com.brizy.io.web.interactions.element.NumericInput;
-import com.brizy.io.web.interactions.element.composite.InputWithUnits;
 import com.brizy.io.web.interactions.element.composite.RadioControl;
 import com.brizy.io.web.interactions.locators.editor.workspace.section.container.item.toolbar.icon.tabs.background.BackgroundLocators;
 import com.brizy.io.web.interactions.page.editor.container.components.toolbar.common.tabs.AbstractTabItem;
 import com.brizy.io.web.interactions.page.editor.container.components.toolbar.variations.button.button.button.corner.Corner;
-import com.brizy.io.web.interactions.page.editor.container.components.toolbar.variations.button.button.button.size.ButtonSize;
 import com.microsoft.playwright.Frame;
 import lombok.AccessLevel;
 import lombok.experimental.FieldDefaults;
 import lombok.experimental.FieldNameConstants;
+import lombok.extern.slf4j.Slf4j;
 
+import java.util.ArrayList;
 import java.util.List;
 import java.util.function.Supplier;
 
 @FieldNameConstants
 @FieldDefaults(makeFinal = true, level = AccessLevel.PRIVATE)
+@Slf4j
 public class BackgroundTab extends AbstractTabItem {
 
     Supplier<NumericInput> size;
@@ -52,11 +52,13 @@ public class BackgroundTab extends AbstractTabItem {
 
     @Override
     public List<Configuration> getConfigurations() {
-        return List.of(
-                Configuration.builder().name(BackgroundTab.Fields.corner).element(corner).build(),
-                Configuration.builder().name(BackgroundTab.Fields.fill).element(fill).build(),
-                Configuration.builder().name(BackgroundTab.Fields.size).element(size).build()
-        );
+        var listOfConfigurations = new ArrayList<Configuration>() {{
+            add(Configuration.builder().name(Fields.fill).element(fill).build());
+            add(Configuration.builder().name(Fields.size).element(size).build());
+        }};
+        var itemsWereAdded = listOfConfigurations.addAll(corner.get().getConfigurations());
+        log.debug("Items from complex corner element were added {}", itemsWereAdded);
+        return listOfConfigurations;
     }
 
 }

--- a/web-interactions/src/main/java/com/brizy/io/web/interactions/page/editor/container/components/toolbar/variations/icon/icon/IconTab.java
+++ b/web-interactions/src/main/java/com/brizy/io/web/interactions/page/editor/container/components/toolbar/variations/icon/icon/IconTab.java
@@ -8,13 +8,16 @@ import com.microsoft.playwright.Frame;
 import lombok.AccessLevel;
 import lombok.experimental.FieldDefaults;
 import lombok.experimental.FieldNameConstants;
+import lombok.extern.slf4j.Slf4j;
 
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
 import java.util.function.Supplier;
 
 @FieldNameConstants
 @FieldDefaults(makeFinal = true, level = AccessLevel.PRIVATE)
+@Slf4j
 public class IconTab extends AbstractTabItem {
 
     Supplier<IconPicker> iconPicker;
@@ -46,10 +49,12 @@ public class IconTab extends AbstractTabItem {
 
     @Override
     public List<Configuration> getConfigurations() {
-        return List.of(
-                Configuration.builder().name(IconTab.Fields.iconPicker).element(iconPicker).build(),
-                Configuration.builder().name(IconTab.Fields.size).element(size).build()
-        );
+        var configurations = new ArrayList<Configuration>() {{
+            add(Configuration.builder().name(Fields.iconPicker).element(iconPicker).build());
+        }};
+        var itemsWereAdded = configurations.addAll(size.get().getConfigurations());
+        log.debug("Items from complex corner element were added {}", itemsWereAdded);
+        return configurations;
     }
 
 }

--- a/web-test/src/test/java/com/brizy/io/web/test/steps/actions/web_elements/WebElementsSteps.java
+++ b/web-test/src/test/java/com/brizy/io/web/test/steps/actions/web_elements/WebElementsSteps.java
@@ -4,6 +4,7 @@ import com.brizy.io.web.interactions.dto.editor.container.toolbar.Configuration;
 import com.brizy.io.web.interactions.element.ComboBox;
 import com.brizy.io.web.interactions.element.FileUploader;
 import com.brizy.io.web.interactions.element.Input;
+import com.brizy.io.web.interactions.element.NumericInput;
 import com.brizy.io.web.interactions.element.composite.InputWithPopulation;
 import com.brizy.io.web.interactions.element.composite.RadioControl;
 import com.brizy.io.web.interactions.page.editor.EditorPage;
@@ -74,6 +75,16 @@ public class WebElementsSteps {
                 .map(configuration -> ((RadioControl) configuration.get()))
                 .map(radioControl -> radioControl.getActiveControl())
                 .map(radioControl -> radioControl.name())
+                .ifPresent(activeValue -> storage.addValue(StorageKey.VALUE, activeValue));
+    }
+
+    @When("get numeric input with name '{}'")
+    public void getNumericInput(String numericInput) {
+        storage.getListValue(StorageKey.TOOLBAR_POPUP_TAB_CONFIGURATIONS, Configuration.class).stream()
+                .filter(el -> el.getName().equals(numericInput))
+                .findFirst()
+                .map(configuration -> configuration.getElement())
+                .map(configuration -> ((NumericInput) configuration.get()))
                 .ifPresent(activeValue -> storage.addValue(StorageKey.VALUE, activeValue));
     }
 

--- a/web-test/src/test/java/com/brizy/io/web/test/steps/validations/web_elements/WebElementsSteps.java
+++ b/web-test/src/test/java/com/brizy/io/web/test/steps/validations/web_elements/WebElementsSteps.java
@@ -1,5 +1,6 @@
 package com.brizy.io.web.test.steps.validations.web_elements;
 
+import com.brizy.io.web.interactions.element.NumericInput;
 import com.brizy.io.web.interactions.page.editor.EditorPage;
 import com.brizy.io.web.test.data.service.TestDataFileService;
 import com.brizy.io.web.test.enums.StorageKey;
@@ -34,6 +35,14 @@ public class WebElementsSteps {
         Assertions.assertThat(expectedActiveItem)
                 .describedAs("Expecting to have <%s> active radio control", expectedActiveItem)
                 .isEqualToIgnoringCase(storage.getValue(StorageKey.VALUE, String.class));
+    }
+
+    @Then("the following numeric value is set: {}")
+    public void theFollowingValueIsSet(Long expectedValue) {
+        Assertions.assertThat(storage.getValue(StorageKey.VALUE, NumericInput.class))
+                .extracting(numericInput -> numericInput.getValue(Long.class))
+                .describedAs("Expecting to have <%d> as numeric input value", expectedValue)
+                .isEqualTo(expectedValue);
     }
 
 }

--- a/web-test/src/test/resources/features/default_properties/VerifyIconElementDefaultProperties.feature
+++ b/web-test/src/test/resources/features/default_properties/VerifyIconElementDefaultProperties.feature
@@ -23,3 +23,29 @@ Feature: Editor Page - Adding a Icon Element
     Examples:
       | name   | sectionName |
       | ICON_1 | SECTION_1   |
+
+  Scenario Outline: Add <name> element and validate default properties
+    When navigate to home page
+    And wait for editor page to load
+    When clear the layout
+    And open editor pop up
+    When switch to 'Blocks' tab
+    And add section '<sectionName>' to page
+    When prepare the following items to be added to the page:
+      | item | position | parent | name   | sectionName   |
+      | ICON | -        | -      | <name> | <sectionName> |
+    And add the item to the page
+    When get available configurations in the tab 'icon' of 'icon' toolbar item of the '<name>' item from section '<sectionName>'
+    When get active item from 'size' radio group
+    Then the following item is active: CUSTOM
+    When get numeric input with name 'customSize'
+    Then the following numeric value is set: 48
+    When get available configurations in the tab 'background' of 'icon' toolbar item of the '<name>' item from section '<sectionName>'
+    When get active item from 'fill' radio group
+    Then the following item is active: FILL
+    When get active item from 'corner' radio group
+    Then the following item is active: ROUND
+
+    Examples:
+      | name   | sectionName |
+      | ICON_1 | SECTION_1   |

--- a/web-test/src/test/resources/features/default_properties/VerifyVideoConfiguration.feature
+++ b/web-test/src/test/resources/features/default_properties/VerifyVideoConfiguration.feature
@@ -4,7 +4,6 @@ Feature: Editor Page - Adding a Video Element
   I want to add a spacer element
   So that I can see some default properties
 
-  @Test
   Scenario Outline: Add video element and validate default properties
     When navigate to home page
     And wait for editor page to load


### PR DESCRIPTION
* Added new scenario to validate default icon configurations;
* Added new method to get configurations from an advanced element like size/corner that can have custom value;
* Added new steps to get numeric input;
* Added new step to validate numeric input value;
* Fixed constructor for RadioControl<IconSize> instead of using page will use frame;
* Fixed `IconSize` enum members;